### PR TITLE
Removed the logger.debug on root path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,5 +39,4 @@ async def root() -> Dict[str, str]:
     """
     Endpoint for basic connectivity test.
     """
-    logger.debug('root requested')
     return {'message': 'OK'}


### PR DESCRIPTION
I want to remove the ```logger.debug('root requested')``` it serves no purpos and I feel like it cluters the logs.